### PR TITLE
feat: implement sequential task ID management and hard delete

### DIFF
--- a/cmd/addCmd.go
+++ b/cmd/addCmd.go
@@ -56,12 +56,23 @@ func addTask(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	var maxID *uint
+	dbConn.Unscoped().Model(&models.Task{}).Select("MAX(id)").Scan(&maxID)
+
+	var nextID uint
+	if maxID == nil {
+		nextID = 1
+	} else {
+		nextID = *maxID + 1
+	}
+
 	task := models.Task{
 		Title:    taskTitle,
 		Status:   models.StatusPending,
 		Priority: priority,
 		DueDate:  dueDateTime,
 	}
+	task.ID = nextID
 
 	result := dbConn.Create(&task)
 	if result.Error != nil {

--- a/cmd/delCmd.go
+++ b/cmd/delCmd.go
@@ -44,7 +44,7 @@ func deleteTask(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		result = dbConn.Delete(&task)
+		result = dbConn.Unscoped().Delete(&task)
 		if result.Error != nil {
 			fmt.Printf("🚨 Failed to delete the task with ID %s: %v\n", arg, result.Error)
 			failedTasks = append(failedTasks, arg)


### PR DESCRIPTION
## 概要

タスクのID管理を最適化し、タスクの削除と追加を繰り返してもIDが不必要に大きくならないように改善しました。

### 変更内容
- **IDの連続性確保**: addコマンドにて、新しいタスクのIDを「現在の最大ID + 1」として明示的に割り当てるように変更しました。これにより、最後に作成したタスクを削除した後に再度追加した場合、IDが飛ぶことなく再利用されます。
- **物理削除（ハードデリート）の導入**: delコマンドにて、GORMのデフォルトである論理削除（ソフトデリート）ではなく物理削除を行うように変更しました。これにより、`max(id)` をクエリする際に削除済みのレコードに影響されることなく、正確な最大値を判定できるようになります。

### 導入のメリット
- タスクIDが数千、数万と不必要に増え続けるのを防ぎ、CLI上での表示をコンパクトに保ちます。
- ユーザーにとって直感的なID管理（削除した最新の番号が次に使われる）を実現します。

## 検証内容
- **手動動作確認**:
    1. タスクを追加（ID: 1）
    2. タスクを削除
    3. 再度タスクを追加し、IDが再度 1 になることを確認。
    4. 複数のタスクがある状態で途中のIDを削除しても、最大値+1が正しく割り振られることを確認。
- **自動テスト**: `make test` を実行し、既存のタスク追加・表示機能に影響がないことを確認済み。